### PR TITLE
Fix tag page title generation bug

### DIFF
--- a/app/tags/[tag]/page.tsx
+++ b/app/tags/[tag]/page.tsx
@@ -33,7 +33,8 @@ export const generateStaticParams = async () => {
 export default function TagPage({ params }: { params: { tag: string } }) {
   const tag = decodeURI(params.tag)
   // Capitalize first letter and convert space to dash
-  const title = tag[0].toUpperCase() + tag.split(' ').join('-').slice(1)
+  const dashed = tag.split(' ').join('-')
+  const title = dashed.charAt(0).toUpperCase() + dashed.slice(1)
   const filteredPosts = allCoreContent(
     sortPosts(allBlogs.filter((post) => post.tags && post.tags.map((t) => slug(t)).includes(tag)))
   )


### PR DESCRIPTION
## Summary
- capitalize tag page titles correctly by generating a dashed string first

## Testing
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_683fe8e960f08329bbf83a656c5dc160